### PR TITLE
Add auto detect  for video orientation

### DIFF
--- a/RMScannerView.h
+++ b/RMScannerView.h
@@ -85,9 +85,6 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface RMScannerView : UIView <AVCaptureMetadata
  @param flashMode The AVCaptureFlashMode which specifies the flash mode, ON, OFF, or AUTO. */
 - (void)setDeviceFlash:(AVCaptureFlashMode)flashMode;
 
-// Rotate Camera when device will rotate ,call this from -(void)willRotateToInterfaceOrientation:duration:
--(void)setScannerViewOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
-
 @end
 
 @class RMScannerView;

--- a/RMScannerView.m
+++ b/RMScannerView.m
@@ -34,6 +34,12 @@
 
 - (void)initialize {
     self.captureSession = [[AVCaptureSession alloc] init];
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(setScannerViewOrientation:)
+     name:UIDeviceOrientationDidChangeNotification
+     object:nil];
+
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
@@ -76,6 +82,12 @@
     metadataOutput = nil;
     videoInput = nil;
     previewLayer = nil;
+    
+    // Remove orient observer
+    [[NSNotificationCenter defaultCenter]
+     removeObserver:self
+     name:UIDeviceOrientationDidChangeNotification
+     object:nil];
 }
 
 #pragma mark - Scanner Checks
@@ -249,9 +261,7 @@
     previewLayer.frame = self.layer.bounds;
     previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
     previewLayer.position = CGPointMake(CGRectGetMidX(self.layer.bounds), CGRectGetMidY(self.layer.bounds));
-    if ([self.delegate respondsToSelector:@selector(interfaceOrientation)]) {
-        [[previewLayer connection] setVideoOrientation:((AVCaptureVideoOrientation)[(UIViewController *)self.delegate interfaceOrientation])];
-    }
+    [[previewLayer connection] setVideoOrientation:((AVCaptureVideoOrientation)[[UIDevice currentDevice] orientation])];
     if ([self.layer.sublayers containsObject:previewLayer] == NO) [self.layer addSublayer:previewLayer];
 }
 
@@ -441,10 +451,10 @@
     return [translatedPoints copy];
 }
 
--(void)setScannerViewOrientation:(UIInterfaceOrientation)toInterfaceOrientation
+-(void)setScannerViewOrientation:(UIDeviceOrientation)toDeviceOrientation
 {
     if (previewLayer) {
-        [[previewLayer connection] setVideoOrientation:(AVCaptureVideoOrientation)toInterfaceOrientation];
+        [[previewLayer connection] setVideoOrientation:(AVCaptureVideoOrientation)[[UIDevice currentDevice] orientation]];
     }
 }
 

--- a/Scanner App/Scanner App/ViewController.m
+++ b/Scanner App/Scanner App/ViewController.m
@@ -88,9 +88,4 @@
 - (UIBarPosition)positionForBar:(id <UIBarPositioning>)bar {
     return UIBarPositionTopAttached;
 }
-
--(void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
-{
-    [scannerView setScannerViewOrientation:toInterfaceOrientation];
-}
 @end


### PR DESCRIPTION
Hi ,thanks for my last PR . finally I have a solution to detect device orientation without get interface orientation from `UIViewController` .  You do not need `setScannerViewOrientation:` anymore.
